### PR TITLE
Bugfix/patch 11/2021

### DIFF
--- a/coreStreamObject.m
+++ b/coreStreamObject.m
@@ -766,9 +766,14 @@ classdef coreStreamObject < handle
             string = sprintf('\nClass:  %s\nProperties:\n  name:                 %s\n  uuid:                 %s\n  samplingRate:         %i Hz\n  timeStamp:            <1x%i double>\n  numberOfChannels:     %i\n  data:                 <%ix%i %s>\n  event.latencyInFrame: <1x%i double>\n  event.label:          <%ix1 cell>',...
                 class(obj),obj.name,char(obj.uuid),obj.samplingRate,length(obj.timeStamp),obj.numberOfChannels,dim(1),dim(2),obj.precision,length(obj.event.latencyInFrame),length(obj.event.label));
             
-            if iscellstr(obj.unit) && ~isempty(obj.unit{1})
-                 unit = obj.unit{1}; %#ok
-            else unit = 'none';      %#ok
+            if ~isempty(obj.unit)
+                if iscellstr(obj.unit)
+                    unit = obj.unit{1};
+                else
+                    unit = obj.unit;
+                end
+            else
+                unit = 'unknown';      %#ok
             end
             string = sprintf('%s\n  label:                <%ix1 cell>',string, dim(2));
             string = sprintf('%s\n  unit:                 %s',string, unit); %#ok

--- a/dataSource.m
+++ b/dataSource.m
@@ -391,9 +391,17 @@ classdef dataSource < handle
             if nargin < 5, updateGui = true;end
             
             I = false(length(dataObjIndex),1);
-            for k=1:length(dataObjIndex), I(k) = obj.item{dataObjIndex(k)}.isMemoryMappingActive;end
+            for k=1:length(dataObjIndex)
+                I(k) = obj.item{dataObjIndex(k)}.isMemoryMappingActive;
+                if ~I(k)
+                    warning(['Cannot export empty data stream: ' obj.item{dataObjIndex(k)}.name]);
+                end
+            end
             dataObjIndex = dataObjIndex(I);
-            if isempty(dataObjIndex), return;end
+            if isempty(dataObjIndex)
+                warning('Cannot find a nonempty data stream to export, the command will result in no action');
+                return;
+            end
             loc = (1:length(dataObjIndex))';
             for k=1:length(dataObjIndex)
                 if ~isempty(obj.item{dataObjIndex(k)}.label{1}) && ~isempty(strfind(lower(obj.item{dataObjIndex(k)}.label{1}),'unknown'))

--- a/dataSource.m
+++ b/dataSource.m
@@ -824,7 +824,7 @@ try
         ind = unique(streamObj{it}.getTimeIndex(xi));
         x = streamObj{it}.timeStamp(ind)';
         for ch=1:streamObj{it}.numberOfChannels
-            yi = interp1(x,y(ind,ch),xi,'linear');
+            yi = interp1(x,double(y(ind,ch)),xi,'linear');
             fwrite(tfid,yi(:),precision);
         end
         % if srOld, streamObj{it}.samplingRate = srOld;end

--- a/dataSourceXDF.m
+++ b/dataSourceXDF.m
@@ -35,6 +35,9 @@ classdef dataSourceXDF < dataSource
             if ~any(ismember({'.xdf','.xdfz'},ext))
                 error('MoBILAB:isNotXDF',['dataSourceXDF cannot read ''' ext ''' format.']);
             end
+            if exist('eegplugin_xdfimport', 'file')
+                addpath(genpath(fileparts(which('eegplugin_xdfimport'))));
+            end
             if ~exist('load_xdf','file')
                 error('MoBILAB:xdfimportMissing','xdfimport plugin is missing.')
             end
@@ -237,6 +240,11 @@ classdef dataSourceXDF < dataSource
                             eegChannels = ismember(lower(channelType),'eeg');
                             % mmfObj = memmapfile(streams{stream_count}.tmpfile,'Format',{streams{stream_count}.precision...
                             %     [length(eegChannels) length(streams{stream_count}.time_stamps)] 'x'},'Writable',false);
+                            if all(~eegChannels)
+                                eegChannels = ~eegChannels;
+                                warning("Although the stream is marked as EEG, there are no channels tagged with this type. " + ...
+                                    "We will populate the .data field with all the channels assuming they contain EEG.");
+                            end
                             if any(~eegChannels)
                                 auxChannel.label = labels(~eegChannels);
                                 % auxChannel.data = mmfObj.Data.x(~eegChannels,:)';

--- a/glibmobi/DataStreamBrowser.m
+++ b/glibmobi/DataStreamBrowser.m
@@ -20,6 +20,10 @@ classdef DataStreamBrowser < CoreBrowser
         function obj = DataStreamBrowser(streamHandle, plotMode, master)
             if nargin < 2, plotMode = 'standalone';end
             if nargin < 3, master = -1;end
+            if prod(streamHandle.size) == 0
+                warning("Cannot plot an empty stream");
+                return;
+            end
             obj.streamHandle = streamHandle;
             obj.dim = fliplr(size(streamHandle.data));
             obj.addlistener('channelIndex','PostSet',@DataStreamBrowser.updateChannelDependencies);

--- a/mobilabApplication.m
+++ b/mobilabApplication.m
@@ -566,7 +566,7 @@ classdef mobilabApplication < handle
                 case 'folder', guiFun = @ImportFolder;
                 case 'dr_bdf', guiFun = @ImportFromDatariverBDF;
                 case 'mobi'
-                    mobiDataDirectory = uigetdir2('Select the _MoBI folder');
+                    mobiDataDirectory = uigetdir('Select the _MoBI folder');
                     if isnumeric(mobiDataDirectory), return;end
                     if ~exist(mobiDataDirectory,'dir'), return;end
                     suffix = '_MoBI';

--- a/mobilabApplication.m
+++ b/mobilabApplication.m
@@ -287,7 +287,9 @@ classdef mobilabApplication < handle
                 renderer.setClosedIcon(jImageIcon);
                 renderer.setOpenIcon(jImageIcon);
                 renderer.setLeafIcon(jImageIcon);
-                javax.swing.ToolTipManager.sharedInstance(1).registerComponent(jTree);
+                try
+                    javax.swing.ToolTipManager.sharedInstance(1).registerComponent(jTree);
+                end
                 jTree.setCellRenderer(renderer);
                 %set(jTree,'userData',callbacks);
                 set(figureHandle,'userData',callbacks)


### PR DESCRIPTION
Here are several bugfixes in the following areas:

- GUI: Patch to launch the GUI on recent MATLAB versions. Matlab is deprecating raw access to java components bit by bit, so eventually, the GUI will have to be fully rewritten using fully supported visual components.
- XDF import: Removal of unnecessary `xdf` folder inside MoBILAB's `dependency` folder. Auto-detect the `xdfimport` plugin and add it to the path in case it is missing. Bugfix when the stream is tagged as EEG but the individual channels aren't. Normally, channels whose type differs from the stream type are relocated to the `aux` channels, however, to prevent an empty `.data` field, we ignore individual channel types. 